### PR TITLE
add GLM

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -310,5 +310,13 @@
     "symbol": "MLN",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295"
+  },
+  {
+    "name": "Golem",
+    "address": "0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429",
+    "symbol": "GLM",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/assets/master/blockchains/ethereum/assets/0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429/logo.png"
   }
 ]


### PR DESCRIPTION
Hi, adding GLM to the default token list. Requires PR in assets since that's where logoURI links to: https://github.com/sushiswap/assets/pull/12
EDIT: seems the above was included already in https://github.com/sushiswap/assets/pull/13

Token Address: 0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429
Token Name (from contract): Golem Network Token
Token Decimals (from contract): 18
Token Symbol (from contract): GLM
SushiSwap pair of Token: 0x56820f78efd1061d174f7a460cfd9d8e4283069b

Link to the official homepage of token: https://golem.network/
Link to CoinMarketCap or CoinGecko page of token: https://coinmarketcap.com/currencies/golem-network-tokens/