### PR TITLE
Added RiverDoge

### DIFF
--- a/tokens/moonriver.json
+++ b/tokens/moonriver.json
@@ -6,5 +6,13 @@
     "decimals": 18,
     "chainId": 1285,
     "logoURI": "https://raw.githubusercontent.com/sushiswap/icons/master/token/movr.jpg"
+  },
+  {
+    "name": "RivrDoge",
+    "address": "0x5D4360f1Be94bD6f182F09cFE5EF9832e65EB1ac",
+    "symbol": "RivrDoge",
+    "decimals": 18,
+    "chainId": 1285,
+    "logoURI": "https://rivrdoge.com/wp-content/uploads/2021/09/logo.png"
   }
 ]


### PR DESCRIPTION
Was no repo folder for assets to upload image, so used our web host. Instructions online say to use .png -- others appears to be using jpg. We appear to be the first people to request this. Thanks.