### PR TITLE
Fix SquidDAO decimal configuration

### DIFF
--- a/tokens/mainnet.json
+++ b/tokens/mainnet.json
@@ -3316,7 +3316,7 @@
     "address": "0x21ad647b8F4Fe333212e735bfC1F36B4941E6Ad2",
     "name": "Squid",
     "symbol": "SQUID",
-    "decimals": 18,
+    "decimals": 9,
     "logoURI": "https://raw.githubusercontent.com/sushiswap/assets/master/blockchains/ethereum/assets/0x21ad647b8F4Fe333212e735bfC1F36B4941E6Ad2/logo.png"
   },
   {


### PR DESCRIPTION
https://etherscan.io/token/0x21ad647b8F4Fe333212e735bfC1F36B4941E6Ad2 specifies 9 decimals.