### PR TITLE
Fix: missing image for USV

### DIFF
--- a/tokens/matic.json
+++ b/tokens/matic.json
@@ -981,6 +981,6 @@
     "symbol": "USV",
     "decimals": 9,
     "chainId": 137,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/assets/master/blockchains/polygon/assets//logo.png"
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/assets/master/blockchains/polygon/assets/0xAC63686230f64BDEAF086Fe6764085453ab3023F/logo.png"
   }
 ]


### PR DESCRIPTION
Image is currently missing on sushi.com. This will fix?